### PR TITLE
fix: update styles so that the border covers all the available width

### DIFF
--- a/src/main/resources/META-INF/frontend/fcEnhancedTabs/fc-enhanced-tabs.css
+++ b/src/main/resources/META-INF/frontend/fcEnhancedTabs/fc-enhanced-tabs.css
@@ -20,11 +20,12 @@
 vaadin-menu-bar[theme~='fc-enhanced-tabs'] {
   width : 100%;
   min-width: var(--lumo-size-m);	
+  box-shadow: inset 0 -1px 0 0 var(--lumo-contrast-10pct);
 }
     
 vaadin-menu-bar-button[theme~='fc-enhanced-tabs'] {
   background: transparent;
-  box-shadow: inset 0 -1px 0 0 var(--lumo-contrast-10pct);
+  box-shadow: none;
 }
 
 vaadin-menu-bar-button[theme~='fc-enhanced-tabs']::before {

--- a/src/main/resources/META-INF/frontend/fcEnhancedTabs/vaadin-menu-bar-button-legacy.css
+++ b/src/main/resources/META-INF/frontend/fcEnhancedTabs/vaadin-menu-bar-button-legacy.css
@@ -21,7 +21,7 @@
 
 :host([theme~='fc-enhanced-tabs']) {
   background: transparent;
-  box-shadow: inset 0 -1px 0 0 var(--lumo-contrast-10pct);
+  box-shadow: none;
 }
 
 :host([theme~='fc-enhanced-tabs'])::before {


### PR DESCRIPTION
Close #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved visual consistency by adjusting the `box-shadow` properties for elements with the `fc-enhanced-tabs` theme.
  - `vaadin-menu-bar[theme~='fc-enhanced-tabs']` now has an inset `box-shadow`.
  - Removed `box-shadow` from `vaadin-menu-bar-button[theme~='fc-enhanced-tabs']` and `vaadin-menu-bar-button-legacy[theme~='fc-enhanced-tabs']`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->